### PR TITLE
Support running on heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+secor: scripts/heroku-run.bash

--- a/pom.xml
+++ b/pom.xml
@@ -264,28 +264,6 @@
             </resource>
         </resources>
         <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>1.1</version>
-                <executions>
-                    <execution>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>git</executable>
-                            <arguments>
-                                <argument>log</argument>
-                                <argument>--pretty=format:build_revision=%H</argument>
-                                <argument>-n1</argument>
-                            </arguments>
-                            <outputFile>target/build.properties</outputFile>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <!-- This forces the dependencies to be copied to target/lib -->
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
@@ -465,6 +443,38 @@
                               <goals>
                                   <goal>sign</goal>
                               </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>heroku</id>
+            <activation>
+              <property>
+                <name>heroku</name>
+              </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.1</version>
+                        <executions>
+                            <execution>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>echo</executable>
+                                    <arguments>
+                                        <argument>build_revision=${env.SOURCE_VERSION}</argument>
+                                    </arguments>
+                                    <outputFile>target/classes/com/pinterest/secor/common/build.properties</outputFile>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/scripts/heroku-run.bash
+++ b/scripts/heroku-run.bash
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# TODO: Support extracting arbitrary configuration values out of the
+# environment. This could be done by pulling all env vars named SECOR_* and
+# converting them to be dot-separated properties.
+
+# For now this is hard-coded to use JSON parsing of messages, partitioned into
+# S3 in time buckets.
+
+# NOTE: if we need to only archive some topics, use this setting:
+#   secor.kafka.topic_filter=.*
+
+java -ea \
+  -Daws.access.key=$AWS_ACCESS_KEY_ID \
+  -Daws.secret.key=$AWS_SECRET_ACCESS_KEY\
+  -Dzookeeper.quorum=$ZOOKEEPER \
+  -Dsecor.s3.bucket=$S3_BUCKET \
+  -Dsecor.max.file.size.bytes=$MAX_FILE_SIZE_BYTES \
+  -Dsecor.max.file.age.seconds=$MAX_FILE_AGE_SECONDS \
+  -Dkafka.seed.broker.host=$KAFKA_HOST \
+  -Dkafka.seed.broker.port=$KAFKA_PORT \
+  -Dsecor.compression.codec=org.apache.hadoop.io.compress.GzipCodec \
+  -Dsecor.file.extension=.gz \
+  -Dsecor.file.reader.writer.factory=com.pinterest.secor.io.impl.DelimitedTextFileReaderWriterFactory \
+  -Dsecor.message.parser.class=com.pinterest.secor.parser.JsonMessageParser \
+  -Dsecor.local.path=/tmp/secor_data/message_logs/partition \
+  -Dlog4j.configuration=log4j.heroku.properties \
+  -Dconfig=secor.prod.partition.properties \
+  -cp target/classes:target/lib/* \
+  com.pinterest.secor.main.ConsumerMain

--- a/src/main/config/log4j.heroku.properties
+++ b/src/main/config/log4j.heroku.properties
@@ -1,0 +1,12 @@
+# log4j logging configuration for running via a Heroku dyno
+
+# All output is sent to standard out.
+
+# root logger.
+log4j.rootLogger=DEBUG, CONSOLE
+
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.Threshold=INFO
+log4j.appender.CONSOLE.Target=System.out
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} [%t] (%C:%L) %-5p %m%n


### PR DESCRIPTION
This required a few things:
- log4j config that only wrote to stdout
- clean up pom to handle heroku deploys where there is no git
- script to launch things and feed in config overrides via env vars.
- Procfile to scale up archivers
